### PR TITLE
Fix numeric length check

### DIFF
--- a/R/reproducibleR.R
+++ b/R/reproducibleR.R
@@ -247,7 +247,7 @@ reproducibleR <- function(options) {
           # generate more informative error message for numeric values
           if (is.numeric(original_value) &&
               is.numeric(current_value))         {
-            if (length(original_value) == 1 && length(current_value == 1)) {
+            if (length(original_value) == 1 && length(current_value) == 1) {
               errmsg <-
                 paste0(
                   "Numbers are not identical: ",


### PR DESCRIPTION
## Summary
- fix numeric length check bug in `reproducibleR`

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68662d0bd5c4832c9d656a96161f005f