### PR TITLE
Fix grammar in documentation

### DIFF
--- a/R/get_reproducibility_summary.R
+++ b/R/get_reproducibility_summary.R
@@ -2,7 +2,7 @@
 
 #' @title Get the total number of failed reproduction attempts
 #'
-#' @param envir Environment to retrieve data from. This defaults to a internal package namespace.
+#' @param envir Environment to retrieve data from. This defaults to an internal package namespace.
 #'
 #' @returns Returns the number of errors encountered when reproducing a Markdown document
 #' @export
@@ -22,7 +22,7 @@ get_num_reproducibility_errors <- function(envir=.cache) {
 #' stores the name of the variable, and `Success` is a boolean variable,
 #' which indicates whether the reproduction attempt was successful.
 #'
-#' @param envir Environment to retrieve data from. This defaults to a internal package namespace.
+#' @param envir Environment to retrieve data from. This defaults to an internal package namespace.
 #'
 #' @returns Returns a data.frame with three columns.
 #' @export

--- a/docs/reference/get_num_reproducibility_errors.html
+++ b/docs/reference/get_num_reproducibility_errors.html
@@ -53,7 +53,7 @@
 
 
 <dl><dt id="arg-envir">envir<a class="anchor" aria-label="anchor" href="#arg-envir"></a></dt>
-<dd><p>Environment to retrieve data from. This defaults to a internal package namespace.</p></dd>
+<dd><p>Environment to retrieve data from. This defaults to an internal package namespace.</p></dd>
 
 </dl></div>
     <div class="section level2">

--- a/docs/reference/get_reproducibility_summary.html
+++ b/docs/reference/get_reproducibility_summary.html
@@ -71,7 +71,7 @@ which indicates whether the reproduction attempt was successful.</p>
 
 
 <dl><dt id="arg-envir">envir<a class="anchor" aria-label="anchor" href="#arg-envir"></a></dt>
-<dd><p>Environment to retrieve data from. This defaults to a internal package namespace.</p></dd>
+<dd><p>Environment to retrieve data from. This defaults to an internal package namespace.</p></dd>
 
 </dl></div>
     <div class="section level2">

--- a/man/get_num_reproducibility_errors.Rd
+++ b/man/get_num_reproducibility_errors.Rd
@@ -7,7 +7,7 @@
 get_num_reproducibility_errors(envir = .cache)
 }
 \arguments{
-\item{envir}{Environment to retrieve data from. This defaults to a internal package namespace.}
+\item{envir}{Environment to retrieve data from. This defaults to an internal package namespace.}
 }
 \value{
 Returns the number of errors encountered when reproducing a Markdown document

--- a/man/get_reproducibility_summary.Rd
+++ b/man/get_reproducibility_summary.Rd
@@ -7,7 +7,7 @@
 get_reproducibility_summary(envir = .cache)
 }
 \arguments{
-\item{envir}{Environment to retrieve data from. This defaults to a internal package namespace.}
+\item{envir}{Environment to retrieve data from. This defaults to an internal package namespace.}
 }
 \value{
 Returns a data.frame with three columns.


### PR DESCRIPTION
## Summary
- correct "a internal" to "an internal" in `R/get_reproducibility_summary.R`
- propagate the change to generated Rd files and HTML docs

## Testing
- `Rscript -e 'roxygen2::roxygenise()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68662e1e0a74832cbbe1911a06e3cf4e