### PR TITLE
Update GitHub action to v4

### DIFF
--- a/R/use_github_action.R
+++ b/R/use_github_action.R
@@ -35,7 +35,7 @@ use_github_action <- function(path = ".github/workflows/reproducibleR.yml") {
     "            quit(status = 1)",
     "          }",
     "          EOF",
-    "      - uses: actions/upload-artifact@v3",
+    "      - uses: actions/upload-artifact@v4",
     "        with:",
     "          name: reproduced-badge",
     "          path: reproduced.svg"


### PR DESCRIPTION
## Summary
- update the `actions/upload-artifact` step in `use_github_action()` to use v4

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b043c41c832cabbeaf3f97ee1382