### PR TITLE
Handle NA success in workflow

### DIFF
--- a/R/use_github_action.R
+++ b/R/use_github_action.R
@@ -2,8 +2,8 @@
 #' @description Creates a GitHub Actions workflow that runs
 #' [isReproducible()] on all R Markdown files in the repository.
 #' The workflow installs Pandoc so that the documents can be rendered.
-#' If all files reproduce successfully, a badge file `reproduced.svg`
-#' is generated.
+#' Depending on the result, a badge file `reproduced.svg` is generated
+#' indicating successful, failing or unknown reproduction status.
 #'
 #' @param path Path to the workflow file to create.
 #'   Defaults to `.github/workflows/reproducibleR.yml`.
@@ -100,7 +100,9 @@ use_github_action <- function(path = ".github/workflows/reproducibleR.yml",
     renv_cmd,
     "          files <- list.files(pattern = '\\\\.[Rr]md$', recursive = TRUE)",
     "          success <- all(sapply(files, isReproducible))",
-    "          if (success) {",
+    "          if (is.na(success)) {",
+    "            download.file('https://img.shields.io/badge/reproducibility_status-unknown-black.svg', 'reproduced.svg', mode = 'wb')",
+    "          } else if (success) {",
     "            download.file('https://img.shields.io/badge/reproduced-brightgreen.svg', 'reproduced.svg', mode = 'wb')",
     "          } else {",
     "            download.file('https://img.shields.io/badge/reproduced-failing-red.svg', 'reproduced.svg', mode = 'wb')",

--- a/man/use_github_action.Rd
+++ b/man/use_github_action.Rd
@@ -13,5 +13,5 @@ use_github_action(path = ".github/workflows/reproducibleR.yml")
 Invisibly returns the path to the created workflow file.
 }
 \description{
-Creates a GitHub Actions workflow that runs \code{isReproducible()} on all R Markdown files in the repository. The workflow installs Pandoc so that the documents can be rendered. If all files reproduce successfully, a badge file \code{reproduced.svg} is generated.
+Creates a GitHub Actions workflow that runs \code{isReproducible()} on all R Markdown files in the repository. The workflow installs Pandoc so that the documents can be rendered. A badge file \code{reproduced.svg} is generated indicating successful, failing or unknown reproduction status.
 }


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow template to handle NA success values
- clarify description for `use_github_action`

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e1e4e8bac832c8cb3adac673ab899